### PR TITLE
Upgrade Brutality + Phantom Happiness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# See http://help.github.com/ignore-files/ for more about ignoring files.
+# See https://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
 /dist
@@ -13,5 +13,5 @@
 /connect.lock
 /coverage/*
 /libpeerconnection.log
-npm-debug.log
+npm-debug.log*
 testem.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ branches:
 before_install:
 - npm config set spin false
 - npm install -g bower coveralls pr-bumper
+- bower --version
+- npm install phantomjs-prebuilt
+- node_modules/phantomjs-prebuilt/bin/phantomjs --version
 - pr-bumper check
 before_script:
 - "export DISPLAY=:99.0"
@@ -20,8 +23,10 @@ before_script:
 - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
 - sudo dpkg -i google-chrome*.deb
 script:
-- npm run lint
-- ember try:one $EMBER_TRY_SCENARIO
+  - npm run lint
+  # Usually, it's ok to finish the test scenario without reverting
+  #  to the addon's original dependency state, skipping "cleanup".
+  - ember try:one $EMBER_TRY_SCENARIO test --skip-cleanup
 install:
 - npm install
 - bower install
@@ -35,7 +40,9 @@ addons:
     - g++-4.8
 env:
   matrix:
-  - EMBER_TRY_SCENARIO=default
+  # we recommend testing LTS's and latest stable release (bonus points to beta/canary)
+  - EMBER_TRY_SCENARIO=ember-lts-2.4
+  - EMBER_TRY_SCENARIO=ember-lts-2.8
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary
@@ -45,7 +52,6 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
-  - env: EMBER_TRY_SCENARIO=ember-beta
   - env: EMBER_TRY_SCENARIO=ember-canary
 before_deploy:
 - pr-bumper bump

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016
+Copyright (c) 2017
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/bower.json
+++ b/bower.json
@@ -3,9 +3,8 @@
   "dependencies": {
     "chai": "~2.3.0",
     "chai-jquery": "^2.0.1",
-    "ember": "~2.8.0",
-    "ember-cli-shims": "0.1.1",
-    "ember-cli-test-loader": "0.2.2",
+    "ember": "~2.10.0",
+    "ember-cli-shims": "0.1.3",
     "ember-mocha-adapter": "~0.3.1",
     "mocha": "~2.2.4",
     "sinon-chai": "^2.8.0"

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,30 +1,25 @@
+/* jshint node:true*/
 module.exports = {
   scenarios: [
     {
-      name: 'default',
-      bower: {
-        dependencies: { }
-      }
-    },
-    {
-      name: 'ember-2-0',
+      name: 'ember-lts-2.4',
       bower: {
         dependencies: {
-          'ember': '~2.0.0'
+          'ember': 'components/ember#lts-2-4'
         },
         resolutions: {
-          'ember': '~2.0.0'
+          'ember': 'lts-2-4'
         }
       }
     },
     {
-      name: 'ember-2-8',
+      name: 'ember-lts-2.8',
       bower: {
         dependencies: {
-          'ember': '~2.8.0'
+          'ember': 'components/ember#lts-2-8'
         },
         resolutions: {
-          'ember': '~2.8.0'
+          'ember': 'lts-2-8'
         }
       }
     },

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,3 +1,4 @@
+/* jshint node:true*/
 'use strict'
 
 module.exports = function (/* environment, appConfig */) {

--- a/package.json
+++ b/package.json
@@ -1,41 +1,43 @@
 {
   "name": "ember-spread",
   "version": "1.0.0",
-  "description": "Dynamic options for dynamic components",
+  "keywords": [
+    "ember-addon"
+  ],
+  "license": "MIT",
+  "author": "Steven Glanzer (https://github.com/sglanzer)",
   "directories": {
     "doc": "doc",
     "test": "tests"
   },
+  "repository": "git@github.com:ciena-blueplanet/ember-spread.git",
   "scripts": {
     "build": "ember build",
     "lint": "eslint *.js addon config tests --fix",
     "start": "ember server",
-    "test": "npm run lint && ember test"
+    "test": "npm run lint && ember try:each"
   },
-  "repository": "git@github.com:ciena-blueplanet/ember-spread.git",
-  "engines": {
-    "node": ">= 6.0.0"
+  "dependencies": {
+    "ember-cli-babel": "^5.1.7"
   },
-  "author": "Steven Glanzer (https://github.com/sglanzer)",
-  "license": "MIT",
   "devDependencies": {
-    "broccoli-asset-rev": "^2.4.2",
-    "ember-ajax": "^2.0.1",
-    "ember-cli": "2.8.0",
-    "ember-cli-app-version": "^1.0.0",
+    "broccoli-asset-rev": "^2.4.5",
+    "ember-ajax": "^2.4.1",
+    "ember-cli": "2.10.0",
+    "ember-cli-app-version": "^2.0.0",
     "ember-cli-chai": "0.3.1",
     "ember-cli-code-coverage": "0.3.8",
-    "ember-cli-dependency-checker": "^1.2.0",
-    "ember-cli-htmlbars": "^1.0.3",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.1",
-    "ember-cli-inject-live-reload": "^1.4.0",
+    "ember-cli-dependency-checker": "^1.3.0",
+    "ember-cli-htmlbars": "^1.0.10",
+    "ember-cli-htmlbars-inline-precompile": "^0.3.3",
+    "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-mocha": "0.13.1",
     "ember-cli-release": "^0.2.9",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-code-snippet": "1.8.0",
-    "ember-data": "^2.8.0",
+    "ember-data": "^2.10.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
     "ember-hook": "1.3.5",
@@ -46,13 +48,10 @@
     "ember-sinon": "0.6.0",
     "eslint": "^3.8.1",
     "eslint-config-frost-standard": "^4.0.0",
-    "loader.js": "^4.0.1"
+    "loader.js": "^4.0.10"
   },
-  "keywords": [
-    "ember-addon"
-  ],
-  "dependencies": {
-    "ember-cli-babel": "^5.1.6"
+  "engines": {
+    "node": ">= 0.12.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "ember-prop-types": "3.2.0",
     "ember-resolver": "^2.0.3",
     "ember-sinon": "0.6.0",
-    "ember-test-utils": "1.2.2",
     "eslint": "^3.8.1",
     "eslint-config-frost-standard": "^4.0.0",
     "loader.js": "^4.0.1"

--- a/testem.js
+++ b/testem.js
@@ -1,3 +1,4 @@
+/* jshint node:true*/
 module.exports = {
   'framework': 'mocha',
   'test_page': 'tests/index.html?hidepassed',

--- a/testem.js
+++ b/testem.js
@@ -7,6 +7,7 @@ module.exports = {
     'Chrome'
   ],
   'launch_in_dev': [
+    'PhantomJS',
     'Chrome'
   ]
 }

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -11,6 +11,10 @@ module.exports = function (environment) {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build
         // e.g. 'with-controller': true
+      },
+      EXTEND_PROTOTYPES: {
+        // Prevent Ember Data from overriding Date.parse.
+        Date: false
       }
     },
 

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -5,8 +5,8 @@ import config from '../../config/environment'
 export default function startApp (attrs) {
   let application
 
-  let attributes = Ember.merge({}, config.APP)
-  attributes = Ember.merge(attributes, attrs) // use defaults, but you can override;
+  // use defaults, but you can override
+  let attributes = Ember.assign({}, config.APP, attrs)
 
   Ember.run(() => {
     application = Application.create(attributes)

--- a/tests/index.html
+++ b/tests/index.html
@@ -21,7 +21,7 @@
     {{content-for "body"}}
     {{content-for "test-body"}}
 
-    <script src="{{rootURL}}testem.js" integrity=""></script>
+    <script src="/testem.js" integrity=""></script>
     <script src="{{rootURL}}assets/vendor.js"></script>
     <script src="{{rootURL}}assets/test-support.js"></script>
     <script src="{{rootURL}}assets/dummy.js"></script>

--- a/tests/integration/components/spread-test.js
+++ b/tests/integration/components/spread-test.js
@@ -1,7 +1,7 @@
 import Ember from 'ember'
 import {expect} from 'chai'
 import {$hook, initialize as initializeHook} from 'ember-hook'
-import {setupComponentTest } from 'ember-mocha'
+import {setupComponentTest} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
 import {beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
@@ -29,7 +29,7 @@ const SpreadComponent = Ember.Component.extend(SpreadMixin, {
 describe('Integration: spread', function () {
   setupComponentTest('spread', {
     integration: true
-  });
+  })
 
   let handler
 

--- a/tests/integration/components/spread-test.js
+++ b/tests/integration/components/spread-test.js
@@ -1,13 +1,11 @@
 import Ember from 'ember'
 import {expect} from 'chai'
 import {$hook, initialize as initializeHook} from 'ember-hook'
-import {describeComponent, it} from 'ember-mocha'
+import {setupComponentTest } from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
-import {beforeEach, describe} from 'mocha'
+import {beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
 import SpreadMixin from 'ember-spread'
-
-import {integration} from 'dummy/tests/helpers/ember-test-utils/describe-component'
 
 const SpreadComponent = Ember.Component.extend(SpreadMixin, {
   // == Properties ============================================================
@@ -28,7 +26,11 @@ const SpreadComponent = Ember.Component.extend(SpreadMixin, {
   }
 })
 
-describeComponent(...integration('spread'), function () {
+describe('Integration: spread', function () {
+  setupComponentTest('spread', {
+    integration: true
+  });
+
   let handler
 
   beforeEach(function () {

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,4 +1,6 @@
 import resolver from './helpers/resolver'
-import { setResolver } from 'ember-mocha'
+import {
+  setResolver
+} from 'ember-mocha'
 
 setResolver(resolver)


### PR DESCRIPTION
#patch#

I had a helluva time trying to figure out why PhantomJS was shitting itself in my app, but I managed to track it down to this addon. A few small changes meant this addon was much friendlier to those of us building against it.

I've additionally upgraded Ember, and buddies, in the process of trying to track down the fails. I've also tweaked the testem config to hopefully catch these sorts of errors going forward.

As an FYI I've blocked edits from the maintainers of your addon to my branch, I'm intending on using it as a stopgap in my app until (if ever) this pull request is accepted.

A quick note: there are surprising fails in a pull request when you don't add a `# Changelog` section to your pull request. Perhaps a pull request template should be added to this project?

# Changelog

* Upgrade Ember, and buddies, to 2.10
* Play nice with PhantomJS