### PR TITLE
Fix the build

### DIFF
--- a/.pr-bumper.json
+++ b/.pr-bumper.json
@@ -1,0 +1,46 @@
+{
+  "ci": {
+    "env": {
+      "branch": "TRAVIS_BRANCH",
+      "buildNumber": "TRAVIS_BUILD_NUMBER",
+      "pr": "TRAVIS_PULL_REQUEST",
+      "repoSlug": "TRAVIS_REPO_SLUG"
+    },
+    "gitUser": {
+      "email": "travis.ci.ciena@gmail.com",
+      "name": "Travis CI"
+    },
+    "provider": "travis"
+  },
+  "isPr": false,
+  "owner": "",
+  "repo": "",
+  "dependencies": {
+    "production": false,
+    "output": {
+      "requirementsFile": "js-requirements.json",
+      "reposFile": "repos",
+      "ignoreFile": "ignore"
+    },
+    "additionalRepos": [
+      {
+        "pattern": "\\s+\"(ember\\-frost\\-\\S+)\"",
+        "url": "https://github.com/ciena-frost/${REPO_NAME}.git"
+      },
+      {
+        "pattern": "\\s+\"(frost\\-\\S+)\"",
+        "url": "https://bitbucket.ciena.com/scm/bp_frost/${REPO_NAME}.git"
+      }
+    ]
+  },
+  "dependencySnapshotFile": "",
+  "vcs": {
+    "domain": "github.com",
+    "env": {
+      "readToken": "RO_GH_TOKEN",
+      "writeToken": "GITHUB_TOKEN"
+    },
+    "provider": "github"
+  },
+  "prependChangelog": true
+}


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [X] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* **Fixed** build by disable dependency snapshot which is causing build to fail and not publish.
Fixes from: https://github.com/ciena-blueplanet/ember-spread/pull/23
* **Updated** to use latest pr-bumper with support for `none`
* **Updated** `sinon-chai` to come from npm instead of bower
* **Updated** `chai-query` to come from npm instead of bower
* **Updated** `ember-cli-code-coverage` to version `0.3.5` until resolution of: https://github.com/kategengler/ember-cli-code-coverage/issues/75
