### PR TITLE
Special properties

### DIFF
--- a/addon/mixins/spread.js
+++ b/addon/mixins/spread.js
@@ -5,8 +5,8 @@
  */
 
 import Ember from 'ember'
-const {Mixin, assert, computed, defineProperty, get, isArray, isNone, typeOf, makeArray} = Ember
-const {keys} = Object
+const {Mixin, assert, computed, defineProperty, get, isArray, isNone, makeArray, typeOf} = Ember
+const {assign, keys} = Object
 import {PropTypes} from 'ember-prop-types'
 
 // Constants
@@ -130,35 +130,33 @@ export default Mixin.create({
         return
       }
 
-      // https://github.com/emberjs/ember.js/blob/v2.12.0/packages/ember-runtime/lib/system/core_object.js#L127-L141
-      if (
-        concatenatedProperties &&
-        concatenatedProperties.length > 0 &&
-        concatenatedProperties.indexOf(key) >= 0
-      ) {
+      // Based on: https://github.com/emberjs/ember.js/blob/v2.12.0/packages/ember-runtime/lib/system/core_object.js#L127-L141
+      if (Array.isArray(concatenatedProperties) && concatenatedProperties.indexOf(key) !== -1) {
         const baseValue = this[key]
 
-        if (baseValue) {
-          if ('function' === typeof baseValue.concat) {
-            this.set(key, baseValue.concat(value))
-          } else {
-            this.set(key, makeArray(baseValue).concat(value))
-          }
-        } else {
+        if (!baseValue) {
           this.set(key, makeArray(value))
+        } else if (typeof baseValue.concat === 'function') {
+          this.set(key, baseValue.concat(value))
+        } else {
+          this.set(key, makeArray(baseValue).concat(value))
         }
 
         return
       }
 
-      // https://github.com/emberjs/ember.js/blob/v2.12.0/packages/ember-runtime/lib/system/core_object.js#L143-L149
-      if (
-        mergedProperties &&
-        mergedProperties.length &&
-        mergedProperties.indexOf(key) >= 0
-      ) {
+      // Based on: https://github.com/emberjs/ember.js/blob/v2.12.0/packages/ember-runtime/lib/system/core_object.js#L143-L149
+      if (Array.isArray(mergedProperties) && mergedProperties.indexOf(key) !== -1) {
         const originalValue = this[key]
-        this.set(key, Object.assign({}, originalValue, value))
+
+        if (typeOf(value) === 'object') {
+          if (typeOf(originalValue) === 'object') {
+            this.set(key, assign({}, originalValue, value))
+          } else {
+            this.set(key, assign({}, value))
+          }
+        }
+
         return
       }
 

--- a/addon/mixins/spread.js
+++ b/addon/mixins/spread.js
@@ -5,7 +5,7 @@
  */
 
 import Ember from 'ember'
-const {Mixin, assert, computed, defineProperty, get, isArray, isNone, typeOf} = Ember
+const {Mixin, assert, computed, defineProperty, get, isArray, isNone, typeOf, makeArray} = Ember
 const {keys} = Object
 import {PropTypes} from 'ember-prop-types'
 
@@ -97,27 +97,68 @@ export default Mixin.create({
 
   /**
    * Create local properties for each property in the spread hash.
-   * Functions are set directly against the local object, while all
-   * other properties are readOnly computed properties to retain
-   * observer behavior
+   * Functions are set directly against the local object. Properties listed in
+   * the component's `concatenatedProperties` or `mergedProperties` are
+   * concatenated / merged appropriately.
+   *
+   * Note: These properties are not observed for changes.
+   *
+   * All other properties are readOnly computed properties to retain
+   * observer behavior.
    *
    * Note: We're currently using the private Ember defineProperty function
    * which is required to establish observer chains (accept computed properties)
    *
    * @param {string} spreadProperty - the name of the local property containing the hash
    * @param {object} spreadableHash - the hash to spread
+   * @param {string[]} staticProperties - properties that are not set up as an alias
    */
-  _defineSpreadProperties (spreadProperty, spreadableHash) {
+  _defineSpreadProperties (spreadProperty, spreadableHash, staticProperties = ['tagName', 'elementId']) {
     assert(
       `${spreadProperty} requires an Ember object or primitive object`,
       ['instance', 'object'].includes(typeOf(spreadableHash))
     )
 
+    const concatenatedProperties = this.get('concatenatedProperties')
+    const mergedProperties = this.get('mergedProperties')
+
     keys(spreadableHash).forEach((key) => {
       const value = spreadableHash[key]
 
-      if (typeOf(value) === 'function') {
+      if (staticProperties.includes(key) || typeOf(value) === 'function') {
         this.set(key, value)
+        return
+      }
+
+      // https://github.com/emberjs/ember.js/blob/v2.12.0/packages/ember-runtime/lib/system/core_object.js#L127-L141
+      if (
+        concatenatedProperties &&
+        concatenatedProperties.length > 0 &&
+        concatenatedProperties.indexOf(key) >= 0
+      ) {
+        const baseValue = this[key]
+
+        if (baseValue) {
+          if ('function' === typeof baseValue.concat) {
+            this.set(key, baseValue.concat(value))
+          } else {
+            this.set(key, makeArray(baseValue).concat(value))
+          }
+        } else {
+          this.set(key, makeArray(value))
+        }
+
+        return
+      }
+
+      // https://github.com/emberjs/ember.js/blob/v2.12.0/packages/ember-runtime/lib/system/core_object.js#L143-L149
+      if (
+        mergedProperties &&
+        mergedProperties.length &&
+        mergedProperties.indexOf(key) >= 0
+      ) {
+        const originalValue = this[key]
+        this.set(key, Object.assign({}, originalValue, value))
         return
       }
 

--- a/addon/mixins/spread.js
+++ b/addon/mixins/spread.js
@@ -122,6 +122,8 @@ export default Mixin.create({
     const concatenatedProperties = this.get('concatenatedProperties')
     const mergedProperties = this.get('mergedProperties')
 
+    // NOTE: disabled linting rule to stay as close as possible to Ember core's code
+    // eslint-disable-next-line complexity
     keys(spreadableHash).forEach((key) => {
       const value = spreadableHash[key]
 

--- a/tests/integration/components/spread-test.js
+++ b/tests/integration/components/spread-test.js
@@ -12,12 +12,20 @@ import sinon from 'sinon'
 const SpreadComponent = Component.extend(SpreadMixin, {
   // == Properties ============================================================
 
+  mergedProperties: ['mergedProperty'],
+  classNames: 'base-class',
   hook: 'spreadTest',
   layout: hbs`
     <div data-test={{hook 'spreadProperty'}}>
       {{property}}
     </div>
+    <div data-test={{hook 'mergedProperty'}}>
+      {{#each-in mergedProperty as |key value|}}
+        {{key}}: {{value}}<br>
+      {{/each-in}}
+    </div>
   `,
+  mergedProperty: {baseValue: true},
 
   // == Actions ===============================================================
 
@@ -45,7 +53,11 @@ describe('ember-spread', function () {
     beforeEach(function () {
       this.setProperties({
         options: {
+          tagName: 'span',
+          elementId: 'test-id',
+          classNames: 'test-class',
           property: 'Neat',
+          mergedProperty: {testValue: true},
           onClick: handler
         }
       })
@@ -59,6 +71,19 @@ describe('ember-spread', function () {
 
     it('should bind spread properties as local properties', function () {
       expect($hook('spreadProperty').text().trim()).to.equal('Neat')
+    })
+
+    it('should set static properties as plain local properties', function () {
+      expect($hook('spreadTest').attr('id')).to.equal('test-id')
+      expect($hook('spreadTest').prop('tagName').toLowerCase()).to.equal('span')
+    })
+
+    it('should concatenate properties, if they are listed as concatenatedProperties', function () {
+      expect($hook('spreadTest').attr('class')).to.include('base-class').and.include('test-class')
+    })
+
+    it('should merge properties, if they are listed as mergedProperties', function () {
+      expect($hook('mergedProperty').text()).to.include('baseValue').and.include('testValue')
     })
 
     it('should bind spread functions as local functions', function () {
@@ -83,7 +108,11 @@ describe('ember-spread', function () {
     beforeEach(function () {
       this.setProperties({
         options: {
+          tagName: 'span',
+          elementId: 'test-id',
+          classNames: 'test-class',
           property: 'Neat',
+          mergedProperty: {testValue: true},
           onClick: handler
         }
       })
@@ -100,6 +129,19 @@ describe('ember-spread', function () {
 
     it('should bind spread properties as local properties', function () {
       expect($hook('spreadProperty').text().trim()).to.equal('Neat')
+    })
+
+    it('should set static properties as plain local properties', function () {
+      expect($hook('spreadTest').attr('id')).to.equal('test-id')
+      expect($hook('spreadTest').prop('tagName').toLowerCase()).to.equal('span')
+    })
+
+    it('should concatenate properties, if they are listed as concatenatedProperties', function () {
+      expect($hook('spreadTest').attr('class')).to.include('base-class').and.include('test-class')
+    })
+
+    it('should merge properties, if they are listed as mergedProperties', function () {
+      expect($hook('mergedProperty').text()).to.include('baseValue').and.include('testValue')
     })
 
     it('should bind spread functions as local functions', function () {

--- a/tests/integration/components/spread-test.js
+++ b/tests/integration/components/spread-test.js
@@ -1,6 +1,6 @@
 import {expect} from 'chai'
 import Ember from 'ember'
-const {Component} = Ember
+const {Component, computed} = Ember
 import {$hook, initialize as initializeHook} from 'ember-hook'
 import {setupComponentTest} from 'ember-mocha'
 import SpreadMixin from 'ember-spread'
@@ -20,12 +20,13 @@ const SpreadComponent = Component.extend(SpreadMixin, {
       {{property}}
     </div>
     <div data-test={{hook 'mergedProperty'}}>
-      {{#each-in mergedProperty as |key value|}}
-        {{key}}: {{value}}<br>
-      {{/each-in}}
+      {{mergedPropertyJson}}
     </div>
   `,
   mergedProperty: {baseValue: true},
+  mergedPropertyJson: computed('mergedProperty', function () {
+    return JSON.stringify(this.get('mergedProperty'))
+  }).readOnly(),
 
   // == Actions ===============================================================
 


### PR DESCRIPTION
Previously it was impossible to pass options like `tagName` or `classNames`. This PR fixes that by introducing `staticProperties` and respecting [`concatenatedProperties`](https://www.emberjs.com/api/classes/Ember.Component.html#property_concatenatedProperties) and [`mergedProperties`](https://www.emberjs.com/api/classes/Ember.Component.html#property_mergedProperties).

`staticProperties` are properties that are forcibly set as regular primitive unobserved properties. Currently only `tagName` and `elementId` are defined as `staticProperties`.

### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
**Added** support for static properties (`tagName`, `elementId`), [`concatenatedProperties`](https://www.emberjs.com/api/classes/Ember.Component.html#property_concatenatedProperties) (`classNames`, ...) and [`mergedProperties`](https://www.emberjs.com/api/classes/Ember.Component.html#property_mergedProperties)