### PR TITLE
Fix version release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,5 @@
 # 3.0.2 (2018-01-03)
-* Delete blueprint
-* Remove `ember-prop-types` from `devDependencies` in _package.json_
-* Add `ember-prop-types` to `dependencies` in _package.json_
-
-## Steps to perform in consuming application
-* Remove `ember-prop-types` from `devDependencies` in _package.json_ if this add-on is the only codebase relying on it.
+There was an error during release and this version should not have been released.  It was supposed to be `4.0.0`.
 
 # 3.0.1 (2017-11-09)
 * Delete blueprint


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [x] #major# - incompatible API change

# CHANGELOG
* Install `bower` devDependency @ `^1.8.2`
* Pin `ember-cli-code-coverage` to `0.3.12`
* Pin `ember-cli-htmlbars-inline-precompile` to `0.3.12`
* Pin `ember-hook` to `1.4.2`
* Remove useLintTree ember-cli-mocha config option
* Pin `ember-code-snippet` to `1.7.0`
* Upgrade `ember-frost-test` to `^4.0.0`
* Upgrade `ember-prop-types` to `^6.0.0`
* Upgrade `ember-cli-frost-blueprints` to `^5.0.0`
* git ignore _package-lock.json_ until officially support Node 8

These changes were actually merged in the `3.0.2` release but it was incorrectly not released as a major so this release does not contain the actual code changes but corrects the versioning.

The version in the _package.json_ file was manually incremented in hopes that perhaps the release issues be experienced have something to do with the version currently being encountered (am just grabbing at straws here) and that changing it will allow a major to be correctly released as desired.
  
  