### PR TITLE
Fix version release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,5 @@
 # 3.0.2 (2018-01-03)
-* Delete blueprint
-* Remove `ember-prop-types` from `devDependencies` in _package.json_
-* Add `ember-prop-types` to `dependencies` in _package.json_
-
-## Steps to perform in consuming application
-* Remove `ember-prop-types` from `devDependencies` in _package.json_ if this add-on is the only codebase relying on it.
+There was an error during release and this version should not have been released.  It was supposed to be `4.0.0`.
 
 # 3.0.1 (2017-11-09)
 * Delete blueprint


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [x] #major# - incompatible API change

# CHANGELOG
Version `3.0.2` was supposed to have been released as a major and all subsequent minor releases have been attempts to remedy this.  We believe we have discovered the culprit which is that a squash merge cannot be used against the PR employing `pr-bumper` so if this deploys correctly as `4.0.0` see the changelog entries for the `3.0.2` release.
  