### PR TITLE
Update coverage.js config file and move to correct directory for addons

### DIFF
--- a/config/coverage.js
+++ b/config/coverage.js
@@ -1,5 +1,0 @@
-module.exports = {
-  excludes: [
-    'tests/dummy/**/*'
-  ]
-}

--- a/tests/dummy/config/coverage.js
+++ b/tests/dummy/config/coverage.js
@@ -1,0 +1,16 @@
+module.exports = {
+  coverageEnvVar: 'COVERAGE',
+  coverageFolder: 'coverage',
+  excludes: [
+    '**/dummy/**/*',
+    '**/mirage/**/*',
+    '**/polyfills/**/*'
+  ],
+  useBabelInstrumenter: true,
+  reporters: [
+    'html',
+    'json-summary',
+    'lcov',
+    'text-summary'
+  ]
+}

--- a/tests/dummy/config/coverage.js
+++ b/tests/dummy/config/coverage.js
@@ -2,9 +2,7 @@ module.exports = {
   coverageEnvVar: 'COVERAGE',
   coverageFolder: 'coverage',
   excludes: [
-    '**/dummy/**/*',
-    '**/mirage/**/*',
-    '**/polyfills/**/*'
+    '**/dummy/**/*'
   ],
   useBabelInstrumenter: true,
   reporters: [


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [X] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

Closes: https://github.com/ciena-blueplanet/ember-spread/issues/43

# CHANGELOG
* **Updated** `coverage.js` code coverage config to include reporters and other settings
* **Updated** `coverage.js` to be located in correct directory for addons: `tests/dummy/config/`