### PR TITLE
Support dynamic property added directly to default options property.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,11 @@ language: node_js
 node_js:
 - 8.6.0
 addons:
+  chrome: stable
   apt:
     sources:
     - ubuntu-toolchain-r-test
-    - google-chrome
     packages:
-    - google-chrome-stable
     - g++-4.8
   firefox: latest
 cache:

--- a/README.md
+++ b/README.md
@@ -107,18 +107,3 @@ Template instance
   )
 }}
 ```
-
-* If you need completely dynamic properties (added to the hash after instantiation) this can be accomplished
-  by providing a source object and property to observe for property additions
-
-```
-{{component-foo
-  options=foo
-  spreadOptions=(hash
-    source=(hash
-      object=this
-      property='foo'
-    )
-  )
-}}
-```

--- a/addon/mixins/spread.js
+++ b/addon/mixins/spread.js
@@ -4,10 +4,9 @@
  * Spreads the properties from a source object against the root level of the local object
  */
 
-import {isArray, makeArray} from '@ember/array'
-
+import {makeArray} from '@ember/array'
 import {assert} from '@ember/debug'
-import {defineProperty, get} from '@ember/object'
+import {defineProperty, observer} from '@ember/object'
 import {readOnly} from '@ember/object/computed'
 import Mixin from '@ember/object/mixin'
 import {isNone, typeOf} from '@ember/utils'
@@ -48,63 +47,20 @@ export default Mixin.create({
   },
 
   // == Computed Properties ===================================================
-
-  // == Functions =============================================================
-
-  /**
-   * Ember objects have a hook for dealing with previously undefined properties
-   * which allows these properties to be brought into the observer system on-the-fly.
-   *
-   * Sets this object as a listener for any unknown property additions.
-   *
-   * @param {object} sourceObject - the source object for the spread
-   * @param {string} sourceProperty - the source property for the spread
-   * @param {string} spreadProperty - the locally bound property for the spread
-   */
-  _defineSourceListener (sourceObject, sourceProperty, spreadProperty) {
-    // Get or create the array of spread listeners on the source object and add this object
-    const spreadListeners = get(sourceObject, `${sourceProperty}._spreadListeners`)
-    if (isNone(spreadListeners)) {
-      get(sourceObject, sourceProperty).set('_spreadListeners', [
-        {
-          target: this,
-          targetProperty: spreadProperty
-        }
-      ])
-    } else {
-      spreadListeners.push({
-        target: this,
-        targetProperty: spreadProperty
-      })
-    }
-
-    // Define the setUnknownProperty function on the source property so that we can
-    // monitor for the addition of new properties and spread them onto the local object
-    defineProperty(get(sourceObject, sourceProperty), 'setUnknownProperty', undefined,
-      function (key, value) {
-        // Set the property to the given value (the expected normal behavior)
-        this[key] = value
-
-        // For each listening target object (registered via spread options)
-        // spread the new property onto the target object
-        this._spreadListeners.forEach(listener => {
-          if (typeOf(value) === 'function') {
-            listener.target.set(key, value)
-          } else {
-            defineProperty(listener.target, key,
-              readOnly(`${listener.targetProperty}.${key}`)
-            )
-          }
-        })
-
-        // Notify all downstream listeners that the property has changed.
-        // This triggers the first observation of the property for the newly
-        // defined computed property on the target object(s)
-        sourceObject.get(sourceProperty).notifyPropertyChange(key)
+  _sourceChanged: observer(`${SPREAD_PROPERTY}`, 'spreadOptions.source.object.options',
+    function () {
+      const {propertyPath, spreadSource} = this._getSpreadSource()
+      if (spreadSource === undefined) {
+        this._resetSpreadProperties()
+      } else if (spreadSource.setUnknownProperty === undefined) {
+        this._resetSpreadProperties()
+        this._addSetUnsupportedProperty(propertyPath)
       }
-    )
-  },
-
+      if (spreadSource) {
+        this._defineSpreadProperties(propertyPath, spreadSource)
+      }
+    }),
+  // == Functions =============================================================
   /**
    * Create local properties for each property in the spread hash.
    * Functions are set directly against the local object. Properties listed in
@@ -158,7 +114,7 @@ export default Mixin.create({
         } else {
           this.set(key, makeArray(baseValue).concat(value))
         }
-
+        this.notifyPropertyChange(`${key}`)
         return
       }
 
@@ -174,32 +130,13 @@ export default Mixin.create({
             this.set(key, assign({}, value))
           }
         }
-
+        this.notifyPropertyChange(`${key}`)
         return
       }
 
       defineProperty(this, key, readOnly(`${spreadProperty}.${key}`))
+      this.notifyPropertyChange(`${key}`)
     })
-  },
-
-  /**
-   * Get the source object and property for the spread hash
-   *
-   * @returns {object} - the source object and property for the spread hash
-   */
-  _getSourceContext () {
-    return {
-      sourceObject: this.get('spreadOptions.source.object'),
-      sourceProperty: this.get('spreadOptions.source.property')
-    }
-  },
-
-  /**
-   * @param {object} listener - a listener object for setUnknownProperty
-   * @returns {boolean} - true if the given listener came from this object
-   */
-  _isLocalListener (listener) {
-    return listener.target === this
   },
 
   /**
@@ -212,18 +149,18 @@ export default Mixin.create({
    * Note: We're currently using the private Ember defineProperty function
    * which is required to establish observer chains (accept computed properties)
    *
-   * @param {object} spreadHash - the hash to remove
    */
-  _resetSpreadProperties (spreadHash) {
+  _resetSpreadProperties () {
     const staticProperties = ['tagName', 'elementId']
     const concatenatedProperties = this.concatenatedProperties || makeArray()
     const mergedProperties = this.mergedProperties || makeArray()
+    const spreadProperties = this.get('_spreadProperties')
 
-    if (isNone(spreadHash)) {
+    if (isNone(spreadProperties)) {
       return
     }
 
-    keys(spreadHash).forEach(key => {
+    spreadProperties.forEach(key => {
       // We don't reset tagName, elementId, concatenatedProperties and
       // mergedProperties as we won't support change them on the fly.
       if (staticProperties.includes(key) ||
@@ -237,135 +174,55 @@ export default Mixin.create({
       // going to remove all registered computed properties.
       defineProperty(this, key, undefined, undefined)
     })
-  },
-
-  /**
-   * This function works the same as _defineSpreadProperties with leaving `staticProperties`,
-   * `concatenatedProperties` and `mergedProperties` untouched.
-   *
-   * Note: We're currently using the private Ember defineProperty function
-   * which is required to establish observer chains (accept computed properties)
-   *
-   * @param {string} spreadProperty - the name of the local property containing the hash
-   * @param {object} spreadHash - the hash object to spread
-   */
-  _redefineSpreadProperties (spreadProperty, spreadHash) {
-    const staticProperties = ['tagName', 'elementId']
-    const concatenatedProperties = this.concatenatedProperties || makeArray()
-    const mergedProperties = this.mergedProperties || makeArray()
-
-    if (isNone(spreadHash)) {
-      return
-    }
-
-    keys(spreadHash).forEach(key => {
-      if (EXCLUDED_PROPERTIES.includes(key)) {
-        return
-      }
-
-      // We won't support changing tagName, elementId, concatenatedProperties and
-      // mergedProperties on the fly.
-      if (staticProperties.includes(key) ||
-        concatenatedProperties.includes(key) ||
-        mergedProperties.includes(key)
-      ) {
-        return
-      }
-
-      defineProperty(this, key, readOnly(`${spreadProperty}.${key}`))
-    })
+    this.set('_spreadProperties', new Set())
   },
 
   // == Ember Lifecycle Hooks =================================================
-
   init () {
     this._super(...arguments)
 
-    // Get the spreadable hash
-    const spreadProperty = this.get('spreadOptions.property') || SPREAD_PROPERTY
-    const spreadableHash = this.get(spreadProperty)
-
-    this._watchSpreadPropertiesUpdate(spreadProperty)
-
-    if (isNone(spreadableHash)) {
-      return
+    const {propertyPath, spreadSource} = this._getSpreadSource()
+    if (spreadSource) {
+      const spreadProperties = new Set(Object.keys(spreadSource))
+      this.set('_spreadProperties', spreadProperties)
+      this._defineSpreadProperties(propertyPath, spreadSource)
+      this._addSetUnsupportedProperty(propertyPath)
     }
-
-    // Spread the properties in the hash onto the local object
-    this._defineSpreadProperties(spreadProperty, spreadableHash)
-
-    // Cache the spreadable hash so we can look it up later for cleanup.
-    this.set('_spreadableHash', spreadableHash)
-
-    // The above spread only works on properties that were defined on the
-    // hash when it was passed to this context.  However, if we add a listener
-    // to the original object hash in the original context then we can determine
-    // when a new property is added and define a property in this context on-the-fly
-    const {sourceObject, sourceProperty} = this._getSourceContext()
-    if (isNone(sourceObject) || isNone(sourceProperty)) {
-      return
-    }
-
-    // Define a listener for any new properties on the source property
-    this._defineSourceListener(sourceObject, sourceProperty, spreadProperty)
   },
 
-  /**
-   * Establish an observer that will notify the spread system whenever the source spreadable property
-   * is being replaced entirely. On the event trigger, the callback will go through all existing spread
-   * property and stops any observers attached to them. Then new read only computed properties and
-   * unknownProperty listeners will be created based on the new/replaced source property.
-   *
-   * @param {string} spreadProperty - the name of the local property containing the hash
-   */
-  _watchSpreadPropertiesUpdate (spreadProperty) {
-    const {sourceObject, sourceProperty} = this._getSourceContext()
+  _getSpreadSource () {
+    // Get the source of  spreadable hash, can be either
+    // this.options (default) OR
+    // this.${spreadOptions.property} (custom)
+    // spreadOptions.source.object.options (with dynamic properties)
+    let spreadProperty = this.get('spreadOptions.property') || SPREAD_PROPERTY
+    if (this.get('spreadOptions.source.object')) {
+      spreadProperty = 'spreadOptions.source.object.options'
+    }
+    return {
+      propertyPath: spreadProperty,
+      spreadSource: this.get(spreadProperty)
+    }
+  },
 
-    this.addObserver(`spreadOptions.source.object.${sourceProperty}`, function () {
-      const spreadableHash = this.get(`spreadOptions.source.object.${sourceProperty}`)
-
-      // This block is to prevent the observer from firing twice on single property change.
-      if (this._spreadableHash === spreadableHash) {
-        return
-      }
-
-      this._resetSpreadProperties(this._spreadableHash)
-
-      // Cache the spreadable hash so we can look it up later for cleanup.
-      this.set('_spreadableHash', spreadableHash)
-
-      if (isNone(spreadableHash)) {
-        return
-      }
-
-      // Redefine the spread properties based on the new spreadableHash.
-      this._redefineSpreadProperties(spreadProperty, spreadableHash)
-
-      // A not about removing existing UnknownProperty listeners.
-      // The original listeners are saved on the original source property object, as the object
-      // is completely gone now, we shouldn't worry about removing these listeners.
-      this._defineSourceListener(sourceObject, sourceProperty, spreadProperty)
-    })
+  _addSetUnsupportedProperty (spreadProperty) {
+    const spreadSource = this.get(`${spreadProperty}`)
+    spreadSource.setUnknownProperty = (key, value) => {
+      spreadSource[key] = value
+      this._defineSpreadProperties(spreadProperty, {
+        [`${key}`]: value
+      })
+      this.get('_spreadProperties').add(key)
+    }
   },
 
   willDestroy () {
     this._super(...arguments)
-
-    const {sourceObject, sourceProperty} = this._getSourceContext()
-    if (isNone(sourceObject) || isNone(sourceProperty)) {
-      return
-    }
-
-    const spreadListeners = get(sourceObject, `${sourceProperty}._spreadListeners`)
-
-    // Remove this listener from the source object property
-    if (isArray(spreadListeners)) {
-      spreadListeners.splice(spreadListeners.findIndex(this._isLocalListener), 1)
-    }
+    this._resetSpreadProperties()
+    this.set('_spreadProperties', undefined)
   }
 
   // == DOM Events ============================================================
 
   // == Actions ===============================================================
-
 })

--- a/tests/integration/components/spread-test.js
+++ b/tests/integration/components/spread-test.js
@@ -109,19 +109,20 @@ describe(test.label, function () {
   })
 
   describe('when using a custom spread property', function () {
-    beforeEach(function () {
-      this.setProperties({
-        options: {
-          tagName: 'span',
-          elementId: 'test-id',
-          classNames: 'test-class',
-          property: 'Neat',
-          mergedProperty: {testValue: true},
-          onClick: handler
-        }
-      })
+    describe('standard usage', function () {
+      beforeEach(function () {
+        this.setProperties({
+          options: {
+            tagName: 'span',
+            elementId: 'test-id',
+            classNames: 'test-class',
+            property: 'Neat',
+            mergedProperty: {testValue: true},
+            onClick: handler
+          }
+        })
 
-      this.render(hbs`
+        this.render(hbs`
         {{spread-test
           foo=options
           spreadOptions=(hash
@@ -129,39 +130,74 @@ describe(test.label, function () {
           )
         }}
       `)
-    })
-
-    it('should bind spread properties as local properties', function () {
-      expect($hook('spreadProperty').text().trim()).to.equal('Neat')
-    })
-
-    it('should set static properties as plain local properties', function () {
-      expect($hook('spreadTest').attr('id')).to.equal('test-id')
-      expect($hook('spreadTest').prop('tagName').toLowerCase()).to.equal('span')
-    })
-
-    it('should concatenate properties, if they are listed as concatenatedProperties', function () {
-      expect($hook('spreadTest').attr('class')).to.include('base-class').and.include('test-class')
-    })
-
-    it('should merge properties, if they are listed as mergedProperties', function () {
-      expect($hook('mergedProperty').text()).to.include('baseValue').and.include('testValue')
-    })
-
-    it('should bind spread functions as local functions', function () {
-      // Note: In the spreadTest component above the onClick function
-      // is called directly without retrieving the function using `get`
-      $hook('spreadTest').click()
-      expect(handler).to.have.callCount(1)
-    })
-
-    describe('and a source property changes', function () {
-      beforeEach(function () {
-        this.set('options.property', 'Woah')
       })
 
-      it('should update the local property', function () {
-        expect($hook('spreadProperty').text().trim()).to.equal('Woah')
+      it('should bind spread properties as local properties', function () {
+        expect($hook('spreadProperty').text().trim()).to.equal('Neat')
+      })
+
+      it('should set static properties as plain local properties', function () {
+        expect($hook('spreadTest').attr('id')).to.equal('test-id')
+        expect($hook('spreadTest').prop('tagName').toLowerCase()).to.equal('span')
+      })
+
+      it('should concatenate properties, if they are listed as concatenatedProperties', function () {
+        expect($hook('spreadTest').attr('class')).to.include('base-class').and.include('test-class')
+      })
+
+      it('should merge properties, if they are listed as mergedProperties', function () {
+        expect($hook('mergedProperty').text()).to.include('baseValue').and.include('testValue')
+      })
+
+      it('should bind spread functions as local functions', function () {
+        // Note: In the spreadTest component above the onClick function
+        // is called directly without retrieving the function using `get`
+        $hook('spreadTest').click()
+        expect(handler).to.have.callCount(1)
+      })
+
+      describe('and a source property changes', function () {
+        beforeEach(function () {
+          this.set('options.property', 'Woah')
+        })
+
+        it('should update the local property', function () {
+          expect($hook('spreadProperty').text().trim()).to.equal('Woah')
+        })
+      })
+    })
+
+    describe('dynamic property in custom spread property', function () {
+      beforeEach(function () {
+        this.setProperties({
+          options: {
+            tagName: 'span',
+            elementId: 'test-id',
+            classNames: 'test-class',
+            onClick: handler
+          }
+        })
+
+        this.render(hbs`
+        {{spread-test
+          foo=options
+          spreadOptions=(hash
+            property='foo'
+          )
+        }}
+      `)
+      })
+
+      it('should display rendered value when property is replaced', function () {
+        this.set('options.property', 'Hoth')
+        expect($hook('spreadProperty').text().trim()).to.equal('Hoth')
+      })
+
+      it('should display rendered value with source is replaced', function () {
+        this.set('options', {
+          property: 'Hoth2'
+        })
+        expect($hook('spreadProperty').text().trim()).to.equal('Hoth2')
       })
     })
   })
@@ -297,10 +333,6 @@ describe(test.label, function () {
         this.set('options', EmberObject.create({}))
       })
 
-      it('should still have one property listener', function () {
-        expect(this.get('options._spreadListeners')).to.have.lengthOf(1)
-      })
-
       describe('and source property is replaced by a new object', function () {
         beforeEach(function () {
           this.set('options', EmberObject.create({
@@ -348,16 +380,6 @@ describe(test.label, function () {
       this.set('options', undefined)
     })
 
-    describe('and source property is replaced by an empty object', function () {
-      beforeEach(function () {
-        this.set('options', EmberObject.create({}))
-      })
-
-      it('should still have one property listener', function () {
-        expect(this.get('options._spreadListeners')).to.have.lengthOf(1)
-      })
-    })
-
     describe('and source property is replaced by an new object', function () {
       beforeEach(function () {
         this.set('options', EmberObject.create({
@@ -367,6 +389,16 @@ describe(test.label, function () {
 
       it('should bind listener to source property', function () {
         expect($hook('spreadProperty').text().trim()).to.equal('foo')
+      })
+
+      describe('and source property is replaced by an empty object', function () {
+        beforeEach(function () {
+          this.set('options', EmberObject.create({}))
+        })
+
+        it('should empty the rendered value', function () {
+          expect($hook('spreadProperty').text().trim()).to.equal('')
+        })
       })
     })
   })
@@ -457,6 +489,59 @@ describe(test.label, function () {
           expect($hook('spreadAnotherProperty').text().trim()).to.equal('foo')
           expect($hook('spreadProperty').text().trim()).to.equal('bar')
         })
+      })
+    })
+  })
+
+  describe('when removing previous set property', function () {
+    beforeEach(function () {
+      this.setProperties({
+        options: {
+          property: 'Neat'
+        }
+      })
+
+      this.render(hbs`
+        {{spread-test
+          options=options
+        }}
+      `)
+    })
+
+    it('should empty the displayed value', function () {
+      this.setProperties({
+        options: {}
+      })
+      expect($hook('spreadProperty').text().trim()).to.equal('')
+    })
+  })
+
+  describe('when adding dynamic property in default spread (options)', function () {
+    beforeEach(function () {
+      this.setProperties({
+        options: {}
+      })
+
+      this.render(hbs`
+        {{spread-test
+          options=options
+        }}
+      `)
+    })
+
+    it('should bind spread properties as local properties', function () {
+      this.set('options', {
+        property: 'Sweet'
+      })
+      expect($hook('spreadProperty').text().trim()).to.equal('Sweet')
+    })
+
+    describe('when modify dynamic property once again', function () {
+      beforeEach(function () {
+        this.set('options.property', 'ABC')
+      })
+      it('should update the rendered value', function () {
+        expect($hook('spreadProperty').text().trim()).to.equal('ABC')
       })
     })
   })

--- a/tests/integration/components/spread-test.js
+++ b/tests/integration/components/spread-test.js
@@ -305,6 +305,34 @@ describe(test.label, function () {
         })
       })
     })
+
+    describe('and using a custom spread object property', function () {
+      beforeEach(function () {
+        this.setProperties({
+          options: EmberObject.create({}),
+          otherOptions: {
+            property: 'Superman'
+          }
+        })
+
+        this.render(hbs`
+          {{spread-test
+            foo=otherOptions
+            spreadOptions=(hash
+              property='foo'
+              source=(hash
+                object=this
+                property='otherOptions'
+              )
+            )
+          }}
+        `)
+      })
+
+      it('should render correct value', function () {
+        expect($hook('spreadProperty').text().trim()).to.equal('Superman')
+      })
+    })
   })
 
   describe('when providing source binding and source property is empty object', function () {


### PR DESCRIPTION
#patch#

## Summary
An issue was found where `dynamic added property` was not automatically added and rendered to the component. The support for dynamic property addition is via a non-intuitive setup.  This PR is to facilitate observing any additional property added to the spread source after `init`.

Strategy:
- add `setUnknownProperty` function to the spread source object so that we can detect any additional property that are being added after `init` cycle.
- observe spread source object; when it changes the reference notify target component about the changes.

## Screenshots or recordings
Please provide screenshots or recordings if this PR is modifying the visual UI or UX.

Before fix

![bug](https://user-images.githubusercontent.com/42067693/78158631-813fe080-740f-11ea-9a9b-3a07fd7d217b.gif)
```
{{frost-button
  hook='mySpreadButton'
  options=spreadOptions
  onClick=(action 'onClickHandler')
}}

// controller
spreadOptions: {
    priority: 'primary'
},
actions: {
  updateText () {
    this.spreadOptions.setProperties({
      priority: 'secondary',
      text: '' + Math.random()
    })
  }
}
```

After Fix
![working](https://user-images.githubusercontent.com/42067693/78158846-bfd59b00-740f-11ea-9bc8-907004f11f1d.gif)

# CHANGELOG
* Dynamic addition property in default/custom options will automatically be added to the target. 
